### PR TITLE
Various fixes to make the python test valid

### DIFF
--- a/gapid_tests/command_buffer_tests/vkTrimCommandPool_test/vkTrimCommandPool.py
+++ b/gapid_tests/command_buffer_tests/vkTrimCommandPool_test/vkTrimCommandPool.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gapit_test_framework import gapit_test, GapitTest, require, require_equal
+from gapit_test_framework import gapit_test, GapitTest
+from gapit_test_framework import require, require_equal, require_not_equal
 
 @gapit_test("vkTrimCommandPool_test")
-class EmptyBitCommandPool(GapitTest):
+class TrimCommandPool(GapitTest):
 
     def expect(self):
         """1. Expects a default command pool that is trimmed for redundant
@@ -23,7 +24,7 @@ class EmptyBitCommandPool(GapitTest):
 
         architecture = self.architecture
 
-        trim_pool = require(self.next_call_of("vkTrimCommandPool"))
-        require_equal(device, trim_pool.int_device)
-        require_equal(command_pool.handle, trim_pool.int_commandPool)
-        require_equal(0, trim_pool.flags)
+        trim_command_pool = require(self.next_call_of("vkTrimCommandPool"))
+        require_not_equal(0, trim_command_pool.int_device)
+        require_not_equal(0, trim_command_pool.int_commandPool)
+        require_equal(0, trim_command_pool.flags)

--- a/tools/gapit_test_framework.py
+++ b/tools/gapit_test_framework.py
@@ -320,8 +320,8 @@ class GapitTest(object):
             gapit_args = ['gapit']
             if verbose:
                 gapit_args.extend(['-log-level', 'Debug'])
-            gapit_args.extend(['trace', '-out',
-                               capture_name, '-local-app', host_name])
+            gapit_args.extend(['trace', '-api', 'vulkan', '-out',
+                               capture_name, '-uri', host_name])
             if verbose:
                 subprocess.check_call(gapit_args)
             else:

--- a/tools/gapit_trace_reader.py
+++ b/tools/gapit_trace_reader.py
@@ -464,7 +464,7 @@ def get_device_and_architecture_info_from_trace_file(filename):
         elif line.strip() == "Trace ABI Information:":
             abi_info_str = get_json_str()
             abi_info = json.loads(abi_info_str)
-            memory_layout = abi_info["MemoryLayout"]
+            memory_layout = abi_info["memory_layout"]
             layout_dict = {}
             for t in memory_layout:
                 if not isinstance(memory_layout[t], dict):


### PR DESCRIPTION
This makes the new test pass.

Once can run the test on host with:

```
# Need to have gapit in the PATH, and the vkTrimCommandPool_test executable in the current directory
./gapit_test_framework.py --test-dir ../gapid_tests/ --host --include command_buffer_tests.vkTrimCommandPool_test.TrimCommandPool
```